### PR TITLE
feat: add status and ttl for intent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 all = "deny"
 nursery = "deny"
 pedantic = "deny"
+module_name_repetitions = "allow"
 
 [profile.release]
 codegen-units = 1

--- a/intent/src/error.rs
+++ b/intent/src/error.rs
@@ -1,3 +1,5 @@
+use near_sdk::env;
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub enum ContractError {
@@ -5,6 +7,12 @@ pub enum ContractError {
     BorshDeserializeError,
     Base64EncodeError,
     Base64DecodeError,
+    IntentNotFound,
+    IntentAlreadyExists,
+    IntentExpired,
+    IntentIsExecuting,
+    WrongIntentStatus,
+    IncorrectAmount,
 }
 
 impl AsRef<str> for ContractError {
@@ -14,6 +22,25 @@ impl AsRef<str> for ContractError {
             Self::BorshDeserializeError => "BORSH_DESERIALIZE_ERROR",
             Self::Base64EncodeError => "BASE64_ENCODE_ERROR",
             Self::Base64DecodeError => "BASE64_DECODE_ERROR",
+            Self::IntentNotFound => "INTENT_NOT_FOUND",
+            Self::IntentAlreadyExists => "INTENT_ALREADY_EXISTS",
+            Self::IntentExpired => "INTENT_EXPIRED",
+            Self::IntentIsExecuting => "INTENT_IS_EXECUTING",
+            Self::WrongIntentStatus => "WRONG_INTENT_STATUS",
+            Self::IncorrectAmount => "INCORRECT_AMOUNT",
         }
+    }
+}
+
+pub trait LogUnwrap<T> {
+    fn log_unwrap(self) -> T;
+}
+
+impl<T, E> LogUnwrap<T> for Result<T, E>
+where
+    E: AsRef<str>,
+{
+    fn log_unwrap(self) -> T {
+        self.unwrap_or_else(|e| env::panic_str(e.as_ref()))
     }
 }

--- a/intent/src/lib.rs
+++ b/intent/src/lib.rs
@@ -243,17 +243,15 @@ impl IntentContract {
 
         detailed_intent.set_status(Status::Processing);
 
+        let intent = detailed_intent.get_intent();
         let current_id = env::current_account_id();
-        let promise = if detailed_intent.get_intent().is_expired() {
-            let intent = detailed_intent.get_intent();
 
+        let promise = if detailed_intent.get_intent().is_expired() {
             ext_ft::ext(intent.send.token_id.clone())
                 .with_attached_deposit(NearToken::from_yoctonear(1))
                 .ft_transfer(intent.initiator.clone(), intent.send.amount)
                 .then(Self::ext(current_id).change_intent_status(id, Status::Expired))
         } else {
-            let intent = detailed_intent.get_intent();
-
             if amount != intent.receive.amount {
                 return Err(ContractError::IncorrectAmount);
             }

--- a/intent/src/lib.rs
+++ b/intent/src/lib.rs
@@ -112,7 +112,7 @@ impl IntentContract {
         }
 
         assert!(
-            matches!(detailed_intent.get_status(), Status::Created),
+            matches!(detailed_intent.get_status(), Status::Available),
             "Only intents with created status could be rolled back"
         );
 
@@ -237,7 +237,7 @@ impl IntentContract {
             .get_mut(id)
             .ok_or(ContractError::IntentNotFound)?;
 
-        if !matches!(detailed_intent.get_status(), Status::Created) {
+        if !matches!(detailed_intent.get_status(), Status::Available) {
             return Err(ContractError::WrongIntentStatus);
         }
 

--- a/intent/src/lib.rs
+++ b/intent/src/lib.rs
@@ -1,15 +1,18 @@
-use near_sdk::env::panic_str;
 use near_sdk::json_types::U128;
+use near_sdk::store::lookup_map::Entry;
 use near_sdk::store::{LookupMap, LookupSet};
 use near_sdk::{
     env, ext_contract, log, near, AccountId, BorshStorageKey, NearToken, PanicOnDefault, Promise,
     PromiseOrValue,
 };
 
-use crate::{types::intent::Action, types::Intent};
+use crate::error::{ContractError, LogUnwrap};
+use crate::types::intent::{Action, DetailedIntent, Intent, Status};
 
 pub mod error;
 pub mod types;
+
+const DEFAULT_MIN_TTL: u64 = 60; // 1 minute
 
 #[derive(BorshStorageKey)]
 #[near(serializers=[borsh])]
@@ -25,7 +28,8 @@ pub struct IntentContract {
     owner_id: AccountId,
     supported_tokens: LookupSet<String>,
     allowed_solvers: LookupSet<AccountId>,
-    intents: LookupMap<String, Intent>,
+    intents: LookupMap<String, DetailedIntent>,
+    min_intent_ttl: u64,
 }
 
 #[near]
@@ -40,6 +44,7 @@ impl IntentContract {
             supported_tokens: LookupSet::new(Prefix::SupportedTokens),
             allowed_solvers: LookupSet::new(Prefix::AllowedSolvers),
             intents: LookupMap::new(Prefix::Intents),
+            min_intent_ttl: DEFAULT_MIN_TTL,
         }
     }
 
@@ -59,57 +64,34 @@ impl IntentContract {
         &mut self,
         sender_id: &AccountId,
         amount: U128,
-        msg: &String,
+        msg: String,
     ) -> PromiseOrValue<U128> {
         // Validate that sender_id is in white token list.
         // self.assert_token(&sender_id); // TODO: Check if we need tokens validation.
-        let action = Action::decode(msg)
-            .unwrap_or_else(|e| panic_str(&format!("Action decode error: {}", e.as_ref())));
-
-        log!(format!("{sender_id} : {}: msg: {msg}", amount.0));
+        let action = Action::decode(msg).log_unwrap();
 
         match action {
             Action::CreateIntent((id, intent)) => {
-                assert!(
-                    self.intents.insert(id, intent).is_none(),
-                    "Intent already exists"
+                log!(
+                    "Creating the intent with id: {id} by: {sender_id}, amount: {}",
+                    amount.0
                 );
-
-                PromiseOrValue::Value(0.into())
+                self.create_intent(id, amount, intent).log_unwrap()
             }
-            Action::ExecuteIntent(id) => {
-                let current_id = env::current_account_id();
-                let solver_id = env::signer_account_id();
-                self.assert_solver(&solver_id);
-
-                let intent = self
-                    .intents
-                    .get(&id)
-                    .unwrap_or_else(|| panic_str(&format!("No intent for id: {id}")));
-
-                let promise = if intent.is_expired() {
-                    Self::ext(current_id).rollback_intent(&id)
-                } else {
-                    ext_ft::ext(intent.send.token_id.clone())
-                        .with_attached_deposit(NearToken::from_yoctonear(1))
-                        .ft_transfer(solver_id, intent.send.amount)
-                        .then(
-                            ext_ft::ext(intent.receive.token_id.clone())
-                                .with_attached_deposit(NearToken::from_yoctonear(1))
-                                .ft_transfer(intent.initiator.clone(), intent.receive.amount),
-                        )
-                        .then(Self::ext(current_id).cleanup_intent(&id))
-                };
-
-                PromiseOrValue::Promise(promise)
-            }
+            Action::ExecuteIntent(id) => self.execute_intent(&id, amount).log_unwrap(),
         }
     }
 
-    /// Callback which removes an intent after successful execution.
+    /// Callback which changes a status of the intent.
     #[private]
-    pub fn cleanup_intent(&mut self, intent_id: &String) {
-        self.intents.remove(intent_id);
+    pub fn change_intent_status(&mut self, intent_id: &String, status: Status) {
+        let intent_with_status = self
+            .intents
+            .get_mut(intent_id)
+            .ok_or(ContractError::IntentNotFound)
+            .log_unwrap();
+
+        intent_with_status.set_status(status);
     }
 
     /// Rollback created intent and refund tokens to the intent's initiator.
@@ -119,11 +101,25 @@ impl IntentContract {
     ///
     /// The panic occurs if intent doesn't exist of caller is not allowed.
     pub fn rollback_intent(&mut self, id: &String) -> Promise {
-        let intent = self
+        let detailed_intent = self
             .intents
-            .get(id)
-            .unwrap_or_else(|| panic_str(&format!("No intent for id: {id}")));
+            .get_mut(id)
+            .ok_or(ContractError::IntentNotFound)
+            .log_unwrap();
+
+        if !detailed_intent.could_be_rollbacked() {
+            env::panic_str("Too early to roll back the intent");
+        }
+
+        assert!(
+            matches!(detailed_intent.get_status(), Status::Created),
+            "Only intents with created status could be rolled back"
+        );
+
+        detailed_intent.set_status(Status::Processing);
+
         let predecessor_id = env::predecessor_account_id();
+        let intent = detailed_intent.get_intent();
 
         assert!(
             predecessor_id == intent.initiator
@@ -135,7 +131,7 @@ impl IntentContract {
         ext_ft::ext(intent.send.token_id.clone())
             .with_attached_deposit(NearToken::from_yoctonear(1))
             .ft_transfer(intent.initiator.clone(), intent.send.amount)
-            .then(Self::ext(env::current_account_id()).cleanup_intent(id))
+            .then(Self::ext(env::current_account_id()).change_intent_status(id, Status::RolledBack))
     }
 
     /// Set a new owner of the contract.
@@ -150,13 +146,31 @@ impl IntentContract {
     }
 
     /// Return pending intent by id.
-    pub fn get_intent(&self, id: &String) -> Option<&Intent> {
+    pub fn get_intent(&self, id: &String) -> Option<&DetailedIntent> {
         self.intents.get(id)
     }
 
     /// Check if the provided solver is allowed.
     pub fn is_allowed_solver(&self, solver_id: &AccountId) -> bool {
         self.allowed_solvers.contains(solver_id)
+    }
+
+    /// Set the minimum TTL for the intent.
+    ///
+    /// # Panics
+    ///
+    /// A panic could be thrown if the provided TTL is too long
+    /// or the transaction is invoked not by the owner.
+    pub fn set_min_intent_ttl(&mut self, min_ttl: u64) {
+        self.assert_owner();
+        // Check for too long value of TTL
+        assert!(min_ttl.checked_mul(1000).is_some(), "TTL is too long");
+        self.min_intent_ttl = min_ttl;
+    }
+
+    /// Return the minimum time to live for the intent.
+    pub const fn get_min_intent_ttl(&self) -> u64 {
+        self.min_intent_ttl
     }
 
     fn assert_owner(&self) {
@@ -180,6 +194,82 @@ impl IntentContract {
             self.supported_tokens.contains(token_id.as_str()),
             "Unsupported token"
         );
+    }
+
+    fn create_intent(
+        &mut self,
+        id: String,
+        amount: U128,
+        intent: Intent,
+    ) -> Result<PromiseOrValue<U128>, ContractError> {
+        if amount != intent.send.amount {
+            return Err(ContractError::IncorrectAmount);
+        }
+
+        match self.intents.entry(id) {
+            Entry::Occupied(_) => Err(ContractError::IntentAlreadyExists),
+            Entry::Vacant(entry) => {
+                let detailed_intent = DetailedIntent::new(intent, self.min_intent_ttl);
+                entry.insert(detailed_intent);
+
+                Ok(PromiseOrValue::Value(0.into()))
+            }
+        }
+    }
+
+    fn execute_intent(
+        &mut self,
+        id: &String,
+        amount: U128,
+    ) -> Result<PromiseOrValue<U128>, ContractError> {
+        let solver_id = env::signer_account_id();
+
+        log!(
+            "Executing the intent with id: {id} by: {}, amount: {}",
+            &solver_id,
+            amount.0
+        );
+
+        self.assert_solver(&solver_id);
+
+        let detailed_intent = self
+            .intents
+            .get_mut(id)
+            .ok_or(ContractError::IntentNotFound)?;
+
+        if !matches!(detailed_intent.get_status(), Status::Created) {
+            return Err(ContractError::WrongIntentStatus);
+        }
+
+        detailed_intent.set_status(Status::Processing);
+
+        let current_id = env::current_account_id();
+        let promise = if detailed_intent.get_intent().is_expired() {
+            let intent = detailed_intent.get_intent();
+
+            ext_ft::ext(intent.send.token_id.clone())
+                .with_attached_deposit(NearToken::from_yoctonear(1))
+                .ft_transfer(intent.initiator.clone(), intent.send.amount)
+                .then(Self::ext(current_id).change_intent_status(id, Status::Expired))
+        } else {
+            let intent = detailed_intent.get_intent();
+
+            if amount != intent.receive.amount {
+                return Err(ContractError::IncorrectAmount);
+            }
+
+            ext_ft::ext(intent.send.token_id.clone())
+                .with_attached_deposit(NearToken::from_yoctonear(1))
+                .ft_transfer(solver_id, intent.send.amount)
+                .then(
+                    ext_ft::ext(intent.receive.token_id.clone())
+                        .with_attached_deposit(NearToken::from_yoctonear(1))
+                        .ft_transfer(intent.initiator.clone(), intent.receive.amount),
+                )
+                .then(Self::ext(current_id).change_intent_status(id, Status::Completed))
+        };
+
+        Ok(PromiseOrValue::Promise(promise))
     }
 }
 

--- a/intent/src/types/intent/mod.rs
+++ b/intent/src/types/intent/mod.rs
@@ -7,7 +7,58 @@ use near_sdk::{
 
 use crate::error::ContractError;
 
+/// Intent with status
+#[derive(Debug)]
+#[near(serializers=[borsh, json])]
+pub struct DetailedIntent {
+    /// Intent
+    pub intent: Intent,
+    /// Status of the intent
+    pub status: Status,
+    /// Time of the creation
+    pub created_at: u64,
+    /// Minimum TTL of the intent
+    pub min_ttl: u64,
+}
+
+impl DetailedIntent {
+    /// Create a new intent with status `Created`
+    #[must_use]
+    pub fn new(intent: Intent, min_ttl: u64) -> Self {
+        Self {
+            intent,
+            status: Status::Created,
+            created_at: env::block_timestamp_ms(),
+            min_ttl: min_ttl * 1000, // Safe. Validation for overflow happens in the transaction
+        }
+    }
+
+    /// Get the inner intent
+    #[must_use]
+    pub const fn get_intent(&self) -> &Intent {
+        &self.intent
+    }
+
+    /// Get the status of the intent
+    #[must_use]
+    pub const fn get_status(&self) -> Status {
+        self.status
+    }
+
+    /// Set the status of the intent
+    pub fn set_status(&mut self, status: Status) {
+        self.status = status;
+    }
+
+    /// Check if the intent could be rolled back
+    #[must_use]
+    pub fn could_be_rollbacked(&self) -> bool {
+        env::block_timestamp_ms() - self.created_at > self.min_ttl
+    }
+}
+
 /// Intent for swapping NEP-141 tokens
+#[derive(Debug)]
 #[near(serializers=[borsh, json])]
 pub struct Intent {
     /// Initiator of the intent
@@ -23,6 +74,7 @@ pub struct Intent {
 }
 
 impl Intent {
+    /// Check if the intent is expired
     #[must_use]
     pub fn is_expired(&self) -> bool {
         match self.expiration {
@@ -46,9 +98,9 @@ impl Action {
     ///
     /// `Base64DecodeError`
     /// `BorshDeserializeError`
-    pub fn decode(msg: &str) -> Result<Self, ContractError> {
+    pub fn decode<M: AsRef<str>>(msg: M) -> Result<Self, ContractError> {
         let bytes = STANDARD
-            .decode(msg)
+            .decode(msg.as_ref())
             .map_err(|_| ContractError::Base64DecodeError)?;
 
         Self::try_from_slice(&bytes).map_err(|_| ContractError::BorshDeserializeError)
@@ -79,11 +131,30 @@ pub enum Expiration {
     Block(u64),
 }
 
+/// The struct describes the token and amount of these tokens a user wants to exchange
 #[derive(Debug, Clone)]
 #[near(serializers=[borsh, json])]
 pub struct TokenAmount {
+    /// Token account id
     pub token_id: AccountId,
+    /// Amount of tokens
     pub amount: U128,
+}
+
+/// Intent status
+#[derive(Debug, Clone, Copy)]
+#[near(serializers=[borsh, json])]
+pub enum Status {
+    /// Intent is created by the user and waiting for execution
+    Created,
+    /// Intent is processing
+    Processing,
+    /// Intent is completed by the solver
+    Completed,
+    /// Intent is rolled back by the user or owner
+    RolledBack,
+    /// Intent is expired
+    Expired,
 }
 
 #[test]

--- a/intent/src/types/intent/mod.rs
+++ b/intent/src/types/intent/mod.rs
@@ -27,7 +27,7 @@ impl DetailedIntent {
     pub fn new(intent: Intent, min_ttl: u64) -> Self {
         Self {
             intent,
-            status: Status::Created,
+            status: Status::Available,
             created_at: env::block_timestamp_ms(),
             min_ttl: min_ttl * 1000, // Safe. Validation for overflow happens in the transaction
         }
@@ -145,8 +145,8 @@ pub struct TokenAmount {
 #[derive(Debug, Clone, Copy)]
 #[near(serializers=[borsh, json])]
 pub enum Status {
-    /// Intent is created by the user and waiting for execution
-    Created,
+    /// Intent is created by the user and available for the execution
+    Available,
     /// Intent is processing
     Processing,
     /// Intent is completed by the solver

--- a/intent/src/types/mod.rs
+++ b/intent/src/types/mod.rs
@@ -1,3 +1,3 @@
-pub use intent::Intent;
+pub use intent::{DetailedIntent, Intent};
 
 pub mod intent;

--- a/tests/src/tests/intent/env.rs
+++ b/tests/src/tests/intent/env.rs
@@ -52,4 +52,11 @@ impl Env {
     pub fn solver_id(&self) -> &AccountId {
         self.solver.id()
     }
+
+    pub async fn set_min_ttl(&self, min_ttl: u64) {
+        self.intent
+            .as_account()
+            .set_min_ttl(self.intent.id(), min_ttl)
+            .await;
+    }
 }

--- a/tests/src/tests/intent/mod.rs
+++ b/tests/src/tests/intent/mod.rs
@@ -1,3 +1,4 @@
+use defuse_intent_contract::types::intent::Status;
 use defuse_intent_contract::{types, types::intent::Expiration, types::intent::TokenAmount};
 
 use crate::{
@@ -61,8 +62,8 @@ async fn test_generic_successful_flow() {
     assert_eq!(env.token_b.ft_balance_of(env.solver_id()).await, 0);
 
     // Check that intent has been removed form the state.
-    let intent = env.user.get_intent(env.intent.id(), "1").await;
-    assert!(intent.is_none());
+    let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
+    assert!(matches!(intent.get_status(), Status::Completed));
 }
 
 #[tokio::test]
@@ -158,6 +159,68 @@ async fn test_rollback_intent() {
     assert_eq!(env.token_a.ft_balance_of(env.solver_id()).await, 0);
     assert_eq!(env.token_b.ft_balance_of(env.solver_id()).await, 2000);
 
+    // Decrease TTL to 1 second. (Default 5 min).
+    env.set_min_ttl(1).await;
+
+    // User creates intent for swapping 1000 TokenA to 2000 TokenB.
+    env.user
+        .create_intent(
+            env.token_a.id(),
+            env.intent.id(),
+            "1",
+            types::Intent {
+                initiator: env.user_id().clone(),
+                send: TokenAmount {
+                    token_id: env.token_a.id().clone(),
+                    amount: 1000.into(),
+                },
+                receive: TokenAmount {
+                    token_id: env.token_b.id().clone(),
+                    amount: 2000.into(),
+                },
+                expiration: Expiration::default(),
+                referral: None,
+            },
+        )
+        .await;
+
+    // Check that intent contract owns user's TokenA now.
+    assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 0);
+    assert_eq!(env.token_a.ft_balance_of(env.intent.id()).await, 1000);
+
+    let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
+    assert!(matches!(intent.get_status(), Status::Created));
+
+    // The user decides to roll back intent.
+    let status = env.user.rollback_intent(env.intent.id(), "1").await;
+    assert!(status.is_success());
+
+    let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
+    assert!(matches!(intent.get_status(), Status::RolledBack));
+
+    // Check balances after intent execution.
+    assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 1000);
+    assert_eq!(env.token_a.ft_balance_of(env.solver_id()).await, 0);
+
+    assert_eq!(env.token_b.ft_balance_of(env.user_id()).await, 0);
+    assert_eq!(env.token_b.ft_balance_of(env.solver_id()).await, 2000);
+}
+
+#[tokio::test]
+async fn test_rollback_intent_too_early() {
+    let env = Env::create().await;
+
+    // Deposit 1000 TokenA to the user and 2000 TokenB to the solver.
+    env.token_a.ft_transfer(env.user_id(), 1000).await;
+    env.token_b.ft_transfer(env.solver_id(), 2000).await;
+
+    // Check that the user doesn't have TokenB and the solver TokenA.
+    assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 1000);
+    assert_eq!(env.token_b.ft_balance_of(env.user_id()).await, 0);
+
+    assert_eq!(env.token_a.ft_balance_of(env.solver_id()).await, 0);
+    assert_eq!(env.token_b.ft_balance_of(env.solver_id()).await, 2000);
+
     // User creates intent for swapping 1000 TokenA to 2000 TokenB.
     env.user
         .create_intent(
@@ -187,17 +250,21 @@ async fn test_rollback_intent() {
     let intent = env.user.get_intent(env.intent.id(), "1").await;
     assert!(intent.is_some());
 
-    // The user decides to roll back intent.
-    env.user.rollback_intent(env.intent.id(), "1").await;
+    // The user decides to roll back intent too early.
+    let result = env.user.rollback_intent(env.intent.id(), "1").await;
+    assert!(result.is_failure());
 
-    let intent = env.user.get_intent(env.intent.id(), "1").await;
-    assert!(intent.is_none());
+    let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
+    assert!(matches!(intent.get_status(), Status::Created));
 
     // Check balances after intent execution.
-    assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 1000);
-    assert_eq!(env.token_a.ft_balance_of(env.solver_id()).await, 0);
-
+    assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 0);
     assert_eq!(env.token_b.ft_balance_of(env.user_id()).await, 0);
+
+    // User's tokens should be still locked in the intent contract.
+    assert_eq!(env.token_a.ft_balance_of(env.intent.id()).await, 1000);
+
+    assert_eq!(env.token_a.ft_balance_of(env.solver_id()).await, 0);
     assert_eq!(env.token_b.ft_balance_of(env.solver_id()).await, 2000);
 }
 
@@ -264,8 +331,8 @@ async fn test_expired_intent(past: Expiration, future: Expiration) {
         .execute_intent(env.token_b.id(), env.intent.id(), "1", 2000.into())
         .await;
 
-    let intent = env.user.get_intent(env.intent.id(), "1").await;
-    assert!(intent.is_none());
+    let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
+    assert!(matches!(intent.get_status(), Status::Expired));
 
     // Check balances after intent execution.
     assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 1000);

--- a/tests/src/tests/intent/mod.rs
+++ b/tests/src/tests/intent/mod.rs
@@ -189,7 +189,7 @@ async fn test_rollback_intent() {
     assert_eq!(env.token_a.ft_balance_of(env.intent.id()).await, 1000);
 
     let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
-    assert!(matches!(intent.get_status(), Status::Created));
+    assert!(matches!(intent.get_status(), Status::Available));
 
     // The user decides to roll back intent.
     let status = env.user.rollback_intent(env.intent.id(), "1").await;
@@ -255,7 +255,7 @@ async fn test_rollback_intent_too_early() {
     assert!(result.is_failure());
 
     let intent = env.user.get_intent(env.intent.id(), "1").await.unwrap();
-    assert!(matches!(intent.get_status(), Status::Created));
+    assert!(matches!(intent.get_status(), Status::Available));
 
     // Check balances after intent execution.
     assert_eq!(env.token_a.ft_balance_of(env.user_id()).await, 0);

--- a/tests/src/utils/intent.rs
+++ b/tests/src/utils/intent.rs
@@ -85,7 +85,6 @@ impl Intent for Account {
             .transact()
             .await
             .unwrap();
-        dbg!(&result);
         assert!(result.is_success(), "execution intent error: {result:#?}");
     }
 

--- a/tests/src/utils/intent.rs
+++ b/tests/src/utils/intent.rs
@@ -1,5 +1,6 @@
 use defuse_intent_contract::types;
 use near_sdk::json_types::U128;
+use near_workspaces::result::ExecutionFinalResult;
 use near_workspaces::types::NearToken;
 use near_workspaces::{Account, AccountId};
 use serde_json::json;
@@ -19,11 +20,16 @@ pub trait Intent {
         id: &str,
         amount: U128,
     );
-    async fn rollback_intent(&self, contract_id: &AccountId, id: &str);
+    async fn rollback_intent(&self, contract_id: &AccountId, id: &str) -> ExecutionFinalResult;
     async fn add_solver(&self, contract_id: &AccountId, solver_id: &AccountId);
+    async fn set_min_ttl(&self, contract_id: &AccountId, min_ttl: u64);
 
     // View transactions
-    async fn get_intent(&self, intent_contract_id: &AccountId, id: &str) -> Option<types::Intent>;
+    async fn get_intent(
+        &self,
+        intent_contract_id: &AccountId,
+        id: &str,
+    ) -> Option<types::DetailedIntent>;
 }
 
 impl Intent for Account {
@@ -52,7 +58,6 @@ impl Intent for Account {
             .transact()
             .await
             .unwrap();
-        dbg!(&result);
         assert!(result.is_success(), "creation intent error: {result:#?}");
     }
 
@@ -80,21 +85,19 @@ impl Intent for Account {
             .transact()
             .await
             .unwrap();
+        dbg!(&result);
         assert!(result.is_success(), "execution intent error: {result:#?}");
     }
 
-    async fn rollback_intent(&self, contract_id: &AccountId, id: &str) {
-        let result = self
-            .call(contract_id, "rollback_intent")
+    async fn rollback_intent(&self, contract_id: &AccountId, id: &str) -> ExecutionFinalResult {
+        self.call(contract_id, "rollback_intent")
             .args_json(json!({
                 "id": id
             }))
             .max_gas()
             .transact()
             .await
-            .unwrap();
-        dbg!(&result);
-        assert!(result.is_success(), "intent rollback error: {result:#?}");
+            .unwrap()
     }
 
     async fn add_solver(&self, contract_id: &AccountId, solver_id: &AccountId) {
@@ -109,8 +112,24 @@ impl Intent for Account {
         assert!(result.is_success(), "execution intent error: {result:#?}");
     }
 
+    async fn set_min_ttl(&self, contract_id: &AccountId, min_ttl: u64) {
+        let result = self
+            .call(contract_id, "set_min_intent_ttl")
+            .args_json(json!({
+                "min_ttl": min_ttl
+            }))
+            .transact()
+            .await
+            .unwrap();
+        assert!(result.is_success(), "set min ttl error: {result:#?}");
+    }
+
     // View transactions
-    async fn get_intent(&self, intent_contract_id: &AccountId, id: &str) -> Option<types::Intent> {
+    async fn get_intent(
+        &self,
+        intent_contract_id: &AccountId,
+        id: &str,
+    ) -> Option<types::DetailedIntent> {
         let result = self
             .call(intent_contract_id, "get_intent")
             .args_json(json!({


### PR DESCRIPTION
The PR adds two additional properties to the `Intent`:

- intent status to prevent attempts to withdraw tokens more than once per intent
- minimum TTL for the intent, which doesn't allow to rollback an intent instantly after creation 